### PR TITLE
Fix pprint for Product2

### DIFF
--- a/pprint/src/pprint/Util.scala
+++ b/pprint/src/pprint/Util.scala
@@ -47,13 +47,13 @@ object Util{
   }
 
   def isOperator(ident: String) = {
-    ident(0) match{
+    (ident.size > 0) && (ident(0) match{
       case '<' | '~' | '!' | '@' | '#' | '%' |
            '^' | '*' | '+' | '-' | /*'<' | */
            '>' | '?' | ':' | '=' | '&' |
            '|' | '/' | '\\' => true
       case _ => false
-    }
+    })
   }
   def escapeChar(c: Char,
                  sb: StringBuilder,

--- a/pprint/test/src/test/pprint/ClassDefs.scala
+++ b/pprint/test/src/test/pprint/ClassDefs.scala
@@ -173,6 +173,13 @@ case class Result2(name : String,
 
 case class GeoCoding2(results : List[Result2], status: String)
 
+object Issue28{
+  class MyProduct2 extends Product2[String, Int] {
+    override def _1: String = "asdf"
+    override def _2: Int = 333
+    override def canEqual(that: Any): Boolean = false
+  }
+}
 object Issue94{
   class Foo(val x: String){
     override def toString = x

--- a/pprint/test/src/test/pprint/ClassDefs.scala
+++ b/pprint/test/src/test/pprint/ClassDefs.scala
@@ -180,6 +180,7 @@ object Issue28{
     override def canEqual(that: Any): Boolean = false
   }
 }
+
 object Issue94{
   class Foo(val x: String){
     override def toString = x

--- a/pprint/test/src/test/pprint/DerivationTests.scala
+++ b/pprint/test/src/test/pprint/DerivationTests.scala
@@ -152,6 +152,10 @@ object DerivationTests extends TestSuite{
         days2 == "SECONDS"
       )
     }
+    test("issue28"){
+      val r = new Issue28.MyProduct2 
+      Check(r : Issue28.MyProduct2, """("asdf", 333)""")
+    }
     test("issue92"){
       val r = new Issue92.Rational {
         override def compare(that: Issue92.Rational): Int = ???


### PR DESCRIPTION
This fixes https://github.com/lihaoyi/PPrint/issues/28

We had a similar problem while pprinting `akka.kafka.ConsumerMessage.CommittableMessage`. I found that the problem is reproduced when `Product2` is used.

`Walker.scala:90` calls `Util.isOperator(x.productPrefix)`, but `Product` defines it as an empty string :
```  
def productPrefix = ""
```
So `ident(0)` in `Util.scala:50` fails with `java.lang.StringIndexOutOfBoundsException`

I've added a unit test and my proposition of a fix.