### PR TITLE
Fix displaying higher order functions without proper parenthesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ target/
 .project
 .cache
 .sbtserver
+.metals
 project/.sbtserver
 tags
 nohup.out

--- a/pprint/src/pprint/TPrint.scala
+++ b/pprint/src/pprint/TPrint.scala
@@ -21,7 +21,7 @@ object TPrint extends TPrintGen[TPrint, TPrintColors] with TPrintLowPri{
     def render(implicit cfg: TPrintColors) = f(cfg)
   }
   def make[T](f: TPrintColors => String) = TPrint.lambda[T](f)
-  def get[T](cfg: TPrintColors)(implicit t: TPrint[T]) = t.render(cfg)
+  def get[T](cfg: TPrintColors)(implicit t: TPrint[T], wrap: TWrap[T]) = wrap.getWrapped(t.render(cfg))
   def implicitly[T](implicit t: TPrint[T]): TPrint[T] = t
   implicit val NothingTPrint: TPrint[Nothing] = TPrint.literal("Nothing")
 }

--- a/pprint/test/src/test/pprint/TWrapTests.scala
+++ b/pprint/test/src/test/pprint/TWrapTests.scala
@@ -1,0 +1,30 @@
+package pprint
+
+import utest._
+
+
+object TWrapTests extends TestSuite {
+
+  def check[T](expected: String)(implicit tprint: TPrint[T]) = {
+    val tprinted = tprint.render
+    assert(expected.equals(tprinted))
+  }
+
+  val tests = Tests {
+    test("higherKindedFunctions"){
+      test("simple")(
+        check[(Int => Option[Int]) => Int]("(Int => Option[Int]) => Int")
+      )
+      test("lazy")(
+        check[() => (Int => Option[Int])]("() => Int => Option[Int]")
+      )
+      test("complex")(
+        check[
+          (Int => Option[Int]) => 
+          ((Int => String) => Int) => 
+          (Int => Int)
+        ]("(Int => Option[Int]) => ((Int => String) => Int) => Int => Int")
+      )
+    }
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/lihaoyi/PPrint/issues/44

I added a new typeclass TWrap, it provides `TWrap(true)` instances for all function types and `TWrap(false)` instances for all other types (or where implicit `TWrap[T]` is not available at that site for `T`). Summoning of `TWrap` instances are intentionally omitted for result types since function types associate to right and there is no need to parenthesize them.