### PR TITLE
Provide an option to not escape unicode characters

### DIFF
--- a/pprint/src/pprint/Util.scala
+++ b/pprint/src/pprint/Util.scala
@@ -81,7 +81,7 @@ object Util{
     var i = 0
     val len = s.length
     while (i < len) {
-      Util.escapeChar(s(i), sb)
+      Util.escapeChar(s(i), sb, unicode)
       i += 1
     }
     sb.append('"')

--- a/pprint/src/pprint/Walker.scala
+++ b/pprint/src/pprint/Walker.scala
@@ -46,6 +46,7 @@ object Tree{
 abstract class Walker{
   val tuplePrefix = "scala.Tuple"
   def showFieldNames = true
+  def escapeUnicode = false
   def additionalHandlers: PartialFunction[Any, Tree]
   def treeify(x: Any): Tree = additionalHandlers.lift(x).getOrElse{
     x match{
@@ -54,7 +55,7 @@ abstract class Walker{
       case x: Char =>
         val sb = new StringBuilder
         sb.append('\'')
-        Util.escapeChar(x, sb)
+        Util.escapeChar(x, sb, escapeUnicode)
         sb.append('\'')
         Tree.Literal(sb.toString)
       case x: Byte => Tree.Literal(x.toString)
@@ -65,7 +66,7 @@ abstract class Walker{
       case x: Double => Tree.Literal(x.toString)
       case x: String =>
         if (x.exists(c => c == '\n' || c == '\r')) Tree.Literal("\"\"\"" + x + "\"\"\"")
-        else Tree.Literal(Util.literalize(x))
+        else Tree.Literal(Util.literalize(x, escapeUnicode))
 
       case x: Symbol => Tree.Literal("'" + x.name)
 

--- a/pprint/test/src/test/pprint/AdvancedTests.scala
+++ b/pprint/test/src/test/pprint/AdvancedTests.scala
@@ -1,6 +1,7 @@
 package test.pprint
 
 import utest._
+import pprint.PPrinter
 
 import scala.collection.SortedMap
 
@@ -183,6 +184,23 @@ object AdvancedTests extends TestSuite{
             assert(count == 4)
           }
         }
+      }
+
+      test("unicode"){
+        val withEscaping = new PPrinter(){
+          override def escapeUnicode = true
+        }
+        val withoutEscaping = new PPrinter(){
+          override def escapeUnicode = false
+        }
+
+        val toCheck = List("foo", "йцук", "漢字")
+
+        val withEscapingRes = withEscaping.apply(toCheck).plainText
+        val withoutEscapingRes = withoutEscaping.apply(toCheck).plainText
+
+        assert(withEscapingRes == "List(\"foo\", \"\\u0439\\u0446\\u0443\\u043a\", \"\\u6f22\\u5b57\")")
+        assert(withoutEscapingRes == """List("foo", "йцук", "漢字")""")
       }
     }
   }

--- a/pprint/test/src/test/pprint/AdvancedTests.scala
+++ b/pprint/test/src/test/pprint/AdvancedTests.scala
@@ -187,12 +187,8 @@ object AdvancedTests extends TestSuite{
       }
 
       test("unicode"){
-        val withEscaping = new PPrinter(){
-          override def escapeUnicode = true
-        }
-        val withoutEscaping = new PPrinter(){
-          override def escapeUnicode = false
-        }
+        val withEscaping = new PPrinter(escapeUnicode = true)
+        val withoutEscaping = new PPrinter(escapeUnicode = false)
 
         val toCheck = List("foo", "йцук", "漢字")
 

--- a/pprint/test/src/test/pprint/UnitTests.scala
+++ b/pprint/test/src/test/pprint/UnitTests.scala
@@ -9,9 +9,8 @@ object UnitTests extends TestSuite{
 
   val tests = TestSuite{
     test("escapeChar"){
-      def check(c: Char, expected: String) = {
-
-        val escaped = pprint.Util.escapeChar(c, new StringBuilder).toString
+      def check(c: Char, expected: String, unicode: Boolean = true) = {
+        val escaped = pprint.Util.escapeChar(c, new StringBuilder, unicode).toString
         assert(escaped == expected)
       }
       check('a', "a")
@@ -19,6 +18,8 @@ object UnitTests extends TestSuite{
       check('\n', "\\n")
       check('\\', "\\\\")
       check('\t', "\\t")
+      check('й', "\\u0439", true)
+      check('й', "й", false)
     }
     test("literalize"){
       val simple = pprint.Util.literalize("hi i am a cow")
@@ -28,6 +29,16 @@ object UnitTests extends TestSuite{
       val escaped = pprint.Util.literalize("hi i am a \"cow\"")
       val escapedExpected = """ "hi i am a \"cow\"" """.trim
       assert(escaped == escapedExpected)
+
+      val withUnicodeStr = "with юникод"
+
+      val withUnicodeEscaped = pprint.Util.literalize(withUnicodeStr, true)
+      val withUnicodeEscapedExpected = "\"with \\u044e\\u043d\\u0438\\u043a\\u043e\\u0434\""
+      assert(withUnicodeEscaped == withUnicodeEscapedExpected)
+
+      val withUnicodeUnescaped = pprint.Util.literalize(withUnicodeStr, false)
+      val withUnicodeUnescapedExpected = """ "with юникод" """.trim
+      assert(withUnicodeUnescaped == withUnicodeUnescapedExpected)
     }
     test("concatIter"){
 


### PR DESCRIPTION
This is a fix for #42 

All needed functionality was already defined in the library but wasn't exposed in a `PPrinter` API. 

I added `escapeUnicode` flag to a `Walker`. By default, I set it as `false`. This is an arguable decision because previously all unicode characters were automatically escaped. But I don't see any good reason, why by default we need to escape unicode characters. So I decided to change the default behavior.

Also, I added tests.