### PR TITLE
Fix link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ PPrint [![Gitter Chat][gitter-badge]][gitter-link] [![Build Status][travis-badge
 
 *A Scala library to pretty-print values and types*
 
-[Documentation](https://lihaoyi.github.io/PPrint/)
+[Documentation](https://com-lihaoyi.github.io/PPrint/)


### PR DESCRIPTION
Small typo that does not allow navigate to the documentation from the README in the repo.