### PR TITLE
Fix broken link pointing to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ PPrint [![Gitter Chat][gitter-badge]][gitter-link] [![Build Status][travis-badge
 
 *A Scala library to pretty-print values and types*
 
-[Documentation](https://lihaoyi.github.io/PPrint/)
+[Documentation](https://com-lihaoyi.github.io/PPrint/)


### PR DESCRIPTION
Hi @lihaoyi, existing link to docs in readme gives 404 error.

closes #58, closes #59