### PR TITLE
Add showFieldNames additionalHandlers for case classes/product

### DIFF
--- a/pprint/src-2.11/pprint/ProductSupport.scala
+++ b/pprint/src-2.11/pprint/ProductSupport.scala
@@ -5,4 +5,15 @@ object ProductSupport {
   def treeifyProductElements(x: Product, walker: Walker): Iterator[Tree] =
     x.productIterator.map(x => walker.treeify(x))
 
+  // Implementation taken from https://stackoverflow.com/questions/15718506/scala-how-to-print-case-classes-like-pretty-printed-tree/57080463#57080463
+  def caseClassToMap(cc: Product): Map[String, Any] = {
+    val fieldValues = cc.productIterator.toSet
+    val fields = cc.getClass.getDeclaredFields.toSeq
+      .filterNot(f => f.isSynthetic || java.lang.reflect.Modifier.isStatic(f.getModifiers))
+    fields.map { f =>
+      f.setAccessible(true)
+      f.getName -> f.get(cc)
+    }.filter { case (_, v) => fieldValues.contains(v) }
+      .toMap
+  }
 }

--- a/pprint/src-2.12/pprint/ProductSupport.scala
+++ b/pprint/src-2.12/pprint/ProductSupport.scala
@@ -5,4 +5,15 @@ object ProductSupport {
   def treeifyProductElements(x: Product, walker: Walker): Iterator[Tree] =
     x.productIterator.map(x => walker.treeify(x))
 
+  // Implementation taken from https://stackoverflow.com/questions/15718506/scala-how-to-print-case-classes-like-pretty-printed-tree/57080463#57080463
+  def caseClassToMap(cc: Product): Map[String, Any] = {
+    val fieldValues = cc.productIterator.toSet
+    val fields = cc.getClass.getDeclaredFields.toSeq
+      .filterNot(f => f.isSynthetic || java.lang.reflect.Modifier.isStatic(f.getModifiers))
+    fields.map { f =>
+      f.setAccessible(true)
+      f.getName -> f.get(cc)
+    }.filter { case (k, v) => fieldValues.contains(v) }
+      .toMap
+  }
 }

--- a/pprint/src-2.13/pprint/ProductSupport.scala
+++ b/pprint/src-2.13/pprint/ProductSupport.scala
@@ -13,4 +13,9 @@ object ProductSupport {
       }
   }
 
+  def caseClassToMap(cc: Product): Map[String, Any] =
+    cc.productIterator.zipWithIndex.map{case (c, index) =>
+      val name = cc.productElementName(index)
+      (name, c)
+    }.toMap
 }

--- a/pprint/src-3/ProductSupport.scala
+++ b/pprint/src-3/ProductSupport.scala
@@ -13,4 +13,9 @@ object ProductSupport {
       }
   }
 
+  def caseClassToMap(cc: Product): Map[String, Any] =
+    cc.productIterator.zipWithIndex.map{case (c, index) =>
+      val name = cc.productElementName(index)
+      (name, c)
+    }.toMap
 }


### PR DESCRIPTION
This PR adds functionality for `PPrinter` that allows you to print field names when pretty printing a `case class` (or any type that implements `Product`). It is based off https://stackoverflow.com/questions/15718506/scala-how-to-print-case-classes-like-pretty-printed-tree/57080463#57080463 with adjustments made for Scala 2.13.x and Scala 3.

A handy method was added into onto `PPrinter` called `showFieldNames` which takes a current `PPrinter` and returns a new one that will print field names. Likewise the basic `additionalHandler` implementation has been added to the `PPrinter` companion object as `showFieldNamesHandler`.

Tests still need to be done, but let me know of any design adjustments/concerns.