### PR TITLE
Add a flag to disable unicode escaping, refactor showFieldNames configuration

### DIFF
--- a/pprint/src-2.11/pprint/ProductSupport.scala
+++ b/pprint/src-2.11/pprint/ProductSupport.scala
@@ -2,7 +2,10 @@ package pprint
 
 object ProductSupport {
 
-  def treeifyProductElements(x: Product, walker: Walker): Iterator[Tree] =
-    x.productIterator.map(x => walker.treeify(x))
+  def treeifyProductElements(x: Product,
+                             walker: Walker,
+                             escapeUnicode: Boolean,
+                             showFieldNames: Boolean): Iterator[Tree] =
+    x.productIterator.map(x => walker.treeify(x, escapeUnicode, showFieldNames))
 
 }

--- a/pprint/src-2.12/pprint/ProductSupport.scala
+++ b/pprint/src-2.12/pprint/ProductSupport.scala
@@ -2,7 +2,10 @@ package pprint
 
 object ProductSupport {
 
-  def treeifyProductElements(x: Product, walker: Walker): Iterator[Tree] =
-    x.productIterator.map(x => walker.treeify(x))
+  def treeifyProductElements(x: Product,
+                             walker: Walker,
+                             escapeUnicode: Boolean,
+                             showFieldNames: Boolean): Iterator[Tree] =
+    x.productIterator.map(x => walker.treeify(x, escapeUnicode, showFieldNames))
 
 }

--- a/pprint/src-2.13/pprint/ProductSupport.scala
+++ b/pprint/src-2.13/pprint/ProductSupport.scala
@@ -2,14 +2,17 @@ package pprint
 
 object ProductSupport {
 
-  def treeifyProductElements(x: Product, walker: Walker): Iterator[Tree] = {
-    if (!walker.showFieldNames) x.productIterator.map(x => walker.treeify(x))
+  def treeifyProductElements(x: Product,
+                             walker: Walker,
+                             escapeUnicode: Boolean,
+                             showFieldNames: Boolean): Iterator[Tree] = {
+    if (!showFieldNames) x.productIterator.map(x => walker.treeify(x, escapeUnicode, showFieldNames))
     else x.productElementNames
       .zipWithIndex
       .map {
         case (name, i) =>
           val elem = x.productElement(i)
-          Tree.KeyValue(name, walker.treeify(elem))
+          Tree.KeyValue(name, walker.treeify(elem, escapeUnicode, showFieldNames))
       }
   }
 

--- a/pprint/src-3/ProductSupport.scala
+++ b/pprint/src-3/ProductSupport.scala
@@ -2,14 +2,17 @@ package pprint
 
 object ProductSupport {
 
-  def treeifyProductElements(x: Product, walker: Walker): Iterator[Tree] = {
-    if (!walker.showFieldNames) x.productIterator.map(x => walker.treeify(x))
+  def treeifyProductElements(x: Product,
+                             walker: Walker,
+                             escapeUnicode: Boolean,
+                             showFieldNames: Boolean): Iterator[Tree] = {
+    if (!showFieldNames) x.productIterator.map(x => walker.treeify(x, escapeUnicode, showFieldNames))
     else x.productElementNames
       .zipWithIndex
       .map {
         case (name, i) =>
           val elem = x.productElement(i)
-          Tree.KeyValue(name, walker.treeify(elem))
+          Tree.KeyValue(name, walker.treeify(elem, escapeUnicode, showFieldNames))
       }
   }
 

--- a/pprint/src/pprint/PPrinter.scala
+++ b/pprint/src/pprint/PPrinter.scala
@@ -15,7 +15,7 @@ package pprint
 case class PPrinter(defaultWidth: Int = 100,
                     defaultHeight: Int = 500,
                     defaultIndent: Int = 2,
-                    defaultEscapeUnicode: Boolean = true,
+                    defaultEscapeUnicode: Boolean = false,
                     defaultShowFieldNames: Boolean = true,
                     colorLiteral: fansi.Attrs = fansi.Color.Green,
                     colorApplyPrefix: fansi.Attrs = fansi.Color.Yellow,

--- a/pprint/src/pprint/Util.scala
+++ b/pprint/src/pprint/Util.scala
@@ -81,7 +81,7 @@ object Util{
     var i = 0
     val len = s.length
     while (i < len) {
-      Util.escapeChar(s(i), sb)
+      Util.escapeChar(s(i), sb, unicode)
       i += 1
     }
     sb.append('"')

--- a/pprint/src/pprint/Walker.scala
+++ b/pprint/src/pprint/Walker.scala
@@ -46,6 +46,7 @@ object Tree{
 abstract class Walker{
   val tuplePrefix = "scala.Tuple"
   def showFieldNames = true
+  def escapeUnicode = false
   def additionalHandlers: PartialFunction[Any, Tree]
   def treeify(x: Any): Tree = additionalHandlers.lift(x).getOrElse{
     x match{
@@ -54,7 +55,7 @@ abstract class Walker{
       case x: Char =>
         val sb = new StringBuilder
         sb.append('\'')
-        Util.escapeChar(x, sb)
+        Util.escapeChar(x, sb, escapeUnicode)
         sb.append('\'')
         Tree.Literal(sb.toString)
       case x: Byte => Tree.Literal(x.toString)
@@ -65,7 +66,7 @@ abstract class Walker{
       case x: Double => Tree.Literal(x.toString)
       case x: String =>
         if (x.exists(c => c == '\n' || c == '\r')) Tree.Literal("\"\"\"" + x + "\"\"\"")
-        else Tree.Literal(Util.literalize(x))
+        else Tree.Literal(Util.literalize(x, escapeUnicode))
 
       case x: Symbol => Tree.Literal("'" + x.name)
 

--- a/pprint/src/pprint/Walker.scala
+++ b/pprint/src/pprint/Walker.scala
@@ -45,10 +45,9 @@ object Tree{
 
 abstract class Walker{
   val tuplePrefix = "scala.Tuple"
-  def showFieldNames = true
-  def escapeUnicode = false
+
   def additionalHandlers: PartialFunction[Any, Tree]
-  def treeify(x: Any): Tree = additionalHandlers.lift(x).getOrElse{
+  def treeify(x: Any, escapeUnicode: Boolean, showFieldNames: Boolean): Tree = additionalHandlers.lift(x).getOrElse{
     x match{
 
       case null => Tree.Literal("null")
@@ -74,11 +73,11 @@ abstract class Walker{
         Tree.Apply(
           StringPrefix(x),
           x.iterator.flatMap { case (k, v) =>
-            Seq(Tree.Infix(treeify(k), "->", treeify(v)))
+            Seq(Tree.Infix(treeify(k, escapeUnicode, showFieldNames), "->", treeify(v, escapeUnicode, showFieldNames)))
           }
         )
 
-      case x: Iterable[_] => Tree.Apply(StringPrefix(x), x.iterator.map(x => treeify(x)))
+      case x: Iterable[_] => Tree.Apply(StringPrefix(x), x.iterator.map(x => treeify(x, escapeUnicode, showFieldNames)))
 
       case None => Tree.Literal("None")
 
@@ -89,27 +88,27 @@ abstract class Walker{
         else
           Tree.Literal("non-empty iterator")
 
-      case x: Array[_] => Tree.Apply("Array", x.iterator.map(x => treeify(x)))
+      case x: Array[_] => Tree.Apply("Array", x.iterator.map(x => treeify(x, escapeUnicode, showFieldNames)))
 
       case x: Product =>
         val className = x.getClass.getName
         if (x.productArity == 0) Tree.Lazy(ctx => Iterator(x.toString))
         else if(x.productArity == 2 && Util.isOperator(x.productPrefix)){
           Tree.Infix(
-            treeify(x.productElement(0)),
+            treeify(x.productElement(0), escapeUnicode, showFieldNames),
 
             x.productPrefix,
-            treeify(x.productElement(1))
+            treeify(x.productElement(1), escapeUnicode, showFieldNames)
           )
         } else (className.startsWith(tuplePrefix), className.lift(tuplePrefix.length)) match{
           // leave out tuple1, so it gets printed as Tuple1(foo) instead of (foo)
           // Don't check the whole suffix, because of specialization there may be
           // funny characters after the digit
           case (true, Some('2' | '3' | '4' | '5' | '6' | '7' | '8' | '9')) =>
-            Tree.Apply("", x.productIterator.map(x => treeify(x)))
+            Tree.Apply("", x.productIterator.map(x => treeify(x, escapeUnicode, showFieldNames)))
 
           case _ =>
-            Tree.Apply(x.productPrefix, ProductSupport.treeifyProductElements(x, this))
+            Tree.Apply(x.productPrefix, ProductSupport.treeifyProductElements(x, this, escapeUnicode, showFieldNames))
         }
 
       case x => Tree.Lazy(ctx => Iterator(x.toString))

--- a/pprint/test/src/test/pprint/AdvancedTests.scala
+++ b/pprint/test/src/test/pprint/AdvancedTests.scala
@@ -1,6 +1,7 @@
 package test.pprint
 
 import utest._
+import pprint.PPrinter
 
 import scala.collection.SortedMap
 
@@ -183,6 +184,23 @@ object AdvancedTests extends TestSuite{
             assert(count == 4)
           }
         }
+      }
+
+      test("unicode"){
+        val withEscaping = new PPrinter(){
+          override def escapeUnicode = true
+        }
+        val withoutEscaping = new PPrinter(){
+          override def escapeUnicode = false
+        }
+
+        val toCheck = List("foo", "йцук", "漢字")
+
+        val withEscapingRes = withEscaping.apply(toCheck).plainText
+        val withoutEscapingRes = withoutEscaping.apply(toCheck).plainText
+
+        assert(withEscapingRes == "List(\"foo\", \"\\u0439\\u0446\\u0443\\u043a\", \"\\u6f22\\u5b57\")")
+        assert(withoutEscapingRes == """List("foo", "йцук", "漢字")""")
       }
     }
   }

--- a/pprint/test/src/test/pprint/AdvancedTests.scala
+++ b/pprint/test/src/test/pprint/AdvancedTests.scala
@@ -187,12 +187,8 @@ object AdvancedTests extends TestSuite{
       }
 
       test("unicode"){
-        val withEscaping = new PPrinter(){
-          override def escapeUnicode = true
-        }
-        val withoutEscaping = new PPrinter(){
-          override def escapeUnicode = false
-        }
+        val withEscaping = new PPrinter(escapeUnicode = true)
+        val withoutEscaping = new PPrinter(escapeUnicode = false)
 
         val toCheck = List("foo", "йцук", "漢字")
 

--- a/pprint/test/src/test/pprint/AdvancedTests.scala
+++ b/pprint/test/src/test/pprint/AdvancedTests.scala
@@ -187,8 +187,8 @@ object AdvancedTests extends TestSuite{
       }
 
       test("unicode"){
-        val withEscaping = new PPrinter(escapeUnicode = true)
-        val withoutEscaping = new PPrinter(escapeUnicode = false)
+        val withEscaping = new PPrinter(defaultEscapeUnicode = true)
+        val withoutEscaping = new PPrinter(defaultEscapeUnicode = false)
 
         val toCheck = List("foo", "йцук", "漢字")
 

--- a/pprint/test/src/test/pprint/Check.scala
+++ b/pprint/test/src/test/pprint/Check.scala
@@ -2,12 +2,8 @@ package test.pprint
 import pprint.PPrinter
 
 object Check{
-  val blackWhite = new PPrinter(){
-    override def showFieldNames = false
-  }
-  val color = new PPrinter(){
-    override def showFieldNames = false
-  }
+  val blackWhite = new PPrinter(defaultShowFieldNames = false)
+  val color = new PPrinter(defaultShowFieldNames = false)
   val blackWhiteFields = new PPrinter()
   val colorFields = new PPrinter()
 }

--- a/pprint/test/src/test/pprint/UnitTests.scala
+++ b/pprint/test/src/test/pprint/UnitTests.scala
@@ -9,9 +9,8 @@ object UnitTests extends TestSuite{
 
   val tests = TestSuite{
     test("escapeChar"){
-      def check(c: Char, expected: String) = {
-
-        val escaped = pprint.Util.escapeChar(c, new StringBuilder).toString
+      def check(c: Char, expected: String, unicode: Boolean = true) = {
+        val escaped = pprint.Util.escapeChar(c, new StringBuilder, unicode).toString
         assert(escaped == expected)
       }
       check('a', "a")
@@ -19,6 +18,8 @@ object UnitTests extends TestSuite{
       check('\n', "\\n")
       check('\\', "\\\\")
       check('\t', "\\t")
+      check('й', "\\u0439", true)
+      check('й', "й", false)
     }
     test("literalize"){
       val simple = pprint.Util.literalize("hi i am a cow")
@@ -28,6 +29,16 @@ object UnitTests extends TestSuite{
       val escaped = pprint.Util.literalize("hi i am a \"cow\"")
       val escapedExpected = """ "hi i am a \"cow\"" """.trim
       assert(escaped == escapedExpected)
+
+      val withUnicodeStr = "with юникод"
+
+      val withUnicodeEscaped = pprint.Util.literalize(withUnicodeStr, true)
+      val withUnicodeEscapedExpected = "\"with \\u044e\\u043d\\u0438\\u043a\\u043e\\u0434\""
+      assert(withUnicodeEscaped == withUnicodeEscapedExpected)
+
+      val withUnicodeUnescaped = pprint.Util.literalize(withUnicodeStr, false)
+      val withUnicodeUnescapedExpected = """ "with юникод" """.trim
+      assert(withUnicodeUnescaped == withUnicodeUnescapedExpected)
     }
     test("concatIter"){
 


### PR DESCRIPTION
Supersedes https://github.com/com-lihaoyi/PPrint/pull/55

the new `escapeUnicode` flag defaults to `false`, since unicode characters are common enough nowadays we should expect editors and other UIs to render them without issue. Someone who wants the old behavior can always manually set it to `true`

`showFieldNames` was added in a kind of awkward manner to avoid breaking backwards binary compatibility. It's been long enough that I think a breakage is ok, so I'm moving it to be a default argument like the rest of our pprint configuration values