### PR TITLE
Fix PPrinting of booleans and TPrinting of constant types

### DIFF
--- a/pprint/src-2/TPrintImpl.scala
+++ b/pprint/src-2/TPrintImpl.scala
@@ -222,7 +222,10 @@ object TPrintLowPri{
             .reduceLeft[fansi.Str]((l, r) => l  ++ " with " ++ r)
         (pre + (if (defs.isEmpty) "" else "{" ++ defs.mkString(";") ++ "}"), WrapType.NoWrap)
       case ConstantType(value) =>
-        (value.toString, WrapType.NoWrap)
+        val pprintedValue =
+          pprint.PPrinter.BlackWhite.copy(colorLiteral = fansi.Color.Green).apply(value.value)
+
+        (pprintedValue, WrapType.NoWrap)
     }
   }
 

--- a/pprint/src/pprint/Walker.scala
+++ b/pprint/src/pprint/Walker.scala
@@ -51,12 +51,14 @@ abstract class Walker{
     x match{
 
       case null => Tree.Literal("null")
+      case x: Boolean => Tree.Literal(x.toString)
       case x: Char =>
         val sb = new StringBuilder
         sb.append('\'')
         Util.escapeChar(x, sb, escapeUnicode)
         sb.append('\'')
         Tree.Literal(sb.toString)
+
       case x: Byte => Tree.Literal(x.toString)
       case x: Short => Tree.Literal(x.toString)
       case x: Int => Tree.Literal(x.toString)

--- a/pprint/test/src-2.13/TPrintConstantTests.scala
+++ b/pprint/test/src-2.13/TPrintConstantTests.scala
@@ -1,0 +1,16 @@
+import pprint.{TPrint, TPrintColors}
+import utest._
+
+object TPrintConstantTests extends TestSuite{
+
+  val tests = TestSuite{
+    test("constant"){
+      assert(
+        implicitly[TPrint[123]].render(TPrintColors.Colors) == fansi.Color.Green("123"),
+        implicitly[TPrint["xyz"]].render(TPrintColors.Colors)  == fansi.Color.Green("\"xyz\""),
+        implicitly[TPrint[Seq[true]]].render(TPrintColors.Colors)  == fansi.Color.Green("Seq") ++ "[" ++ fansi.Color.Green("true") ++ "]"
+      )
+    }
+  }
+}
+

--- a/pprint/test/src-2.13/test/pprint/TPrintConstantTests.scala
+++ b/pprint/test/src-2.13/test/pprint/TPrintConstantTests.scala
@@ -1,3 +1,5 @@
+package test.pprint
+
 import pprint.{TPrint, TPrintColors}
 import utest._
 

--- a/pprint/test/src-2/test/pprint/TPrintTests.scala
+++ b/pprint/test/src-2/test/pprint/TPrintTests.scala
@@ -1,6 +1,6 @@
 package test.pprint
 
-import pprint.TPrint
+import pprint.{TPrint, TPrintColors}
 import utest._
 
 object TPrintTests extends TestSuite{
@@ -235,5 +235,16 @@ object TPrintTests extends TestSuite{
       import scala.reflect.runtime.universe._
       check[Nothing]("Nothing")
     }
+    test("constant"){
+      check[123]("123")
+      check["xyz"]("\"xyz\"")
+      check[Seq[true]]("Seq[true]")
+      assert(
+        implicitly[TPrint[123]].render(TPrintColors.Colors) == fansi.Color.Green("123"),
+        implicitly[TPrint["xyz"]].render(TPrintColors.Colors)  == fansi.Color.Green("\"xyz\""),
+        implicitly[TPrint[Seq[true]]].render(TPrintColors.Colors)  == fansi.Color.Green("Seq") ++ "[" ++ fansi.Color.Green("true") ++ "]"
+      )
+    }
   }
 }
+

--- a/pprint/test/src-2/test/pprint/TPrintTests.scala
+++ b/pprint/test/src-2/test/pprint/TPrintTests.scala
@@ -235,16 +235,6 @@ object TPrintTests extends TestSuite{
       import scala.reflect.runtime.universe._
       check[Nothing]("Nothing")
     }
-    test("constant"){
-      check[123]("123")
-      check["xyz"]("\"xyz\"")
-      check[Seq[true]]("Seq[true]")
-      assert(
-        implicitly[TPrint[123]].render(TPrintColors.Colors) == fansi.Color.Green("123"),
-        implicitly[TPrint["xyz"]].render(TPrintColors.Colors)  == fansi.Color.Green("\"xyz\""),
-        implicitly[TPrint[Seq[true]]].render(TPrintColors.Colors)  == fansi.Color.Green("Seq") ++ "[" ++ fansi.Color.Green("true") ++ "]"
-      )
-    }
   }
 }
 

--- a/pprint/test/src/test/pprint/AdvancedTests.scala
+++ b/pprint/test/src/test/pprint/AdvancedTests.scala
@@ -208,7 +208,7 @@ object AdvancedTests extends TestSuite{
       assert(rendered.plainText == "null")
 
     }
-    test("XXX"){
+    test("customProduct2"){
       final class Vec2 (val x: Double, val y: Double) extends Product2[Double, Double] {
         def _1 = x
         def _2 = y


### PR DESCRIPTION
TPrinting of constant types regressed in 0.8.0, while PPrinting of booleans was always missing the colors that they should have had.

This PR fixes both and adds a unit test to avoid regression