### PR TITLE
Add support for Polytypes

### DIFF
--- a/pprint/src-2/TPrintImpl.scala
+++ b/pprint/src-2/TPrintImpl.scala
@@ -222,9 +222,9 @@ object TPrintLowPri{
             .reduceLeft[fansi.Str]((l, r) => l  ++ " with " ++ r)
         (pre + (if (defs.isEmpty) "" else "{" ++ defs.mkString(";") ++ "}"), WrapType.NoWrap)
       case PolyType(typeParams, resultType) =>
-        val params = typeParams.map(t => printArgSyms(t.asInstanceOf[TypeSymbol].typeParams)).mkString("")
+        val params = printArgSyms(typeParams)
         (
-          params + typePrintImplRec(c)(resultType, true),
+          params ++ typePrintImplRec(c)(resultType, true),
           WrapType.NoWrap
         )
       case ConstantType(value) =>

--- a/pprint/src-2/TPrintImpl.scala
+++ b/pprint/src-2/TPrintImpl.scala
@@ -221,6 +221,12 @@ object TPrintLowPri{
             .map(typePrintImplRec(c)(_, true))
             .reduceLeft[fansi.Str]((l, r) => l  ++ " with " ++ r)
         (pre + (if (defs.isEmpty) "" else "{" ++ defs.mkString(";") ++ "}"), WrapType.NoWrap)
+      case PolyType(typeParams, resultType) =>
+        val params = typeParams.map(t => printArgSyms(t.asInstanceOf[TypeSymbol].typeParams)).mkString("")
+        (
+          params + typePrintImplRec(c)(resultType, true),
+          WrapType.NoWrap
+        )
       case ConstantType(value) =>
         val pprintedValue =
           pprint.PPrinter.BlackWhite.copy(colorLiteral = fansi.Color.Green).apply(value.value)

--- a/pprint/test/src-2/test/pprint/TPrintTests.scala
+++ b/pprint/test/src-2/test/pprint/TPrintTests.scala
@@ -246,8 +246,10 @@ object TPrintTests extends TestSuite{
       object Print {
         def tprint[A](a: A)(implicit t: pprint.TPrint[A]) = t.render
       }
-      val rendered = Print.tprint(Bar(1))
-      assert(rendered.toString() == "Bar[[A]Foo[A], Int]")
+      val rendered = Print.tprint(Bar(1)).toString()
+
+      val is213Plus = classOf[Seq[Int]].getName != "scala.collection.Seq"
+      assert(rendered == (if (is213Plus) "Bar[[A]Foo[A], Int]" else "Bar[Foo, Int]"))
     }
   }
 }

--- a/pprint/test/src-2/test/pprint/TPrintTests.scala
+++ b/pprint/test/src-2/test/pprint/TPrintTests.scala
@@ -235,6 +235,20 @@ object TPrintTests extends TestSuite{
       import scala.reflect.runtime.universe._
       check[Nothing]("Nothing")
     }
+    test("polytype"){
+      import scala.language.implicitConversions
+      type Foo[+A] = Unit
+      trait Bar[F[_], A]
+      object Bar {
+        implicit def anyToBar[A](a: A): Bar[Foo, A] = new Bar[Foo, A] {}
+        def apply[F[_], A](b: Bar[F, A]): Bar[F, A] = b
+      }
+      object Print {
+        def tprint[A](a: A)(implicit t: pprint.TPrint[A]) = t.render
+      }
+      val rendered = Print.tprint(Bar(1))
+      assert(rendered.toString() == "Bar[Foo[A], Int]")
+    }
   }
 }
 

--- a/pprint/test/src-2/test/pprint/TPrintTests.scala
+++ b/pprint/test/src-2/test/pprint/TPrintTests.scala
@@ -247,7 +247,7 @@ object TPrintTests extends TestSuite{
         def tprint[A](a: A)(implicit t: pprint.TPrint[A]) = t.render
       }
       val rendered = Print.tprint(Bar(1))
-      assert(rendered.toString() == "Bar[Foo[A], Int]")
+      assert(rendered.toString() == "Bar[[A]Foo[A], Int]")
     }
   }
 }


### PR DESCRIPTION
This PR adds a new case for `PolyType` in TPrintImpl.

Hopefully this resolves:
- https://github.com/com-lihaoyi/PPrint/issues/76
- https://github.com/scalameta/mdoc/issues/615

I've used @mrdziuban's [scastie reproduction](https://scastie.scala-lang.org/mrdziuban/dTRTDOYMREahxoreSLtMLA/1) as a test case.

**Disclaimer**: I don't actually know what these PolyType's should look like.

We can test with the console via `mill -i "pprint.jvm[2.13.4].console"` and see what the compiler gives us:

```
scala> import scala.language.implicitConversions
     |
     | type Foo[+A] = Unit
     |
     | trait Bar[F[_], A]
     |
     | object Bar {
     |   implicit def anyToBar[A](a: A): Bar[Foo, A] = new Bar[Foo, A] {}
     |
     |   def apply[F[_], A](b: Bar[F, A]): Bar[F, A] = b
     | }
     |
     | def tprint[A](a: A)(implicit t: pprint.TPrint[A]) = t.render
import scala.language.implicitConversions
type Foo
trait Bar
object Bar
def tprint[A](a: A)(implicit t: pprint.TPrint[A]): fansi.Str

scala> tprint(Bar(1))
val res0: fansi.Str = Bar[Foo[A], Int]

scala> Bar(1)
val res1: Bar[[+A]Foo[A],Int] = Bar$$anon$1@794cb26b
```

As shown, the compiler prints `Bar[[+A]Foo[A],Int]` ~instead of our `Bar[Foo[A], Int]`.~
~I feel like the `[+A]Foo[A]` is not usually how we'd write this, but happy to be corrected.~

### Update Mar 27th:

We now render Polytypes differently in Scala 2.12 versus 2.13:

Scala 2.13: `Bar[[A]Foo[A], Int]`
Scala 2.12: `Bar[Foo, Int]`

**Disclaimer:** I do not know if this is reasonable. It just so happens to work with minimal changes to PPrint.

