### PR TITLE
Don't use reflection to call Iterable.collectionClassName

### DIFF
--- a/pprint/src-2.13/pprint/StringPrefix.scala
+++ b/pprint/src-2.13/pprint/StringPrefix.scala
@@ -1,5 +1,6 @@
 package pprint
 
-object StringPrefix{
-  def apply(i: Iterable[_]) = i.asInstanceOf[{ def collectionClassName: String }].collectionClassName
+object StringPrefix {
+  def apply(i: Iterable[_]) =
+    scala.collection.internal.pprint.CollectionName.get(i)
 }

--- a/pprint/src-2.13/scala/collection/internal/pprint/CollectionName.scala
+++ b/pprint/src-2.13/scala/collection/internal/pprint/CollectionName.scala
@@ -1,0 +1,7 @@
+package scala.collection.internal.pprint
+
+// needs to be in a scala.* package to call Iterable.collectionClassName (which is private[scala])
+object CollectionName {
+  def get(iterable: scala.collection.Iterable[_]): String =
+    iterable.collectionClassName
+}

--- a/pprint/src-3/StringPrefix.scala
+++ b/pprint/src-3/StringPrefix.scala
@@ -1,7 +1,6 @@
 package pprint
 
-import reflect.Selectable.reflectiveSelectable
-
 object StringPrefix{
-  def apply(i: Iterable[_]) = i.asInstanceOf[{ def collectionClassName: String }].collectionClassName
+  def apply(i: Iterable[_]) =
+    scala.collection.internal.pprint.CollectionName.get(i)
 }

--- a/pprint/src-3/scala/collection/internal/pprint/CollectionName.scala
+++ b/pprint/src-3/scala/collection/internal/pprint/CollectionName.scala
@@ -1,0 +1,7 @@
+package scala.collection.internal.pprint
+
+// needs to be in a scala.* package to call Iterable.collectionClassName (which is private[scala])
+object CollectionName {
+  def get(iterable: scala.collection.Iterable[_]): String =
+    iterable.collectionClassName
+}


### PR DESCRIPTION
This PR makes the calls to `Iterable.collectionClassName` more "standard", that is not reflection-based.

Reflection is an issue on GraalVM native-image, where all collection concrete classes would need to be added to some Graal reflection config for `collectionClassName` to be call-able by reflection.