### PR TITLE
when a string contains `\`, automatically change to `"""`

### DIFF
--- a/pprint/src/pprint/Walker.scala
+++ b/pprint/src/pprint/Walker.scala
@@ -66,7 +66,7 @@ abstract class Walker{
       case x: Float => Tree.Literal(x.toString + "F")
       case x: Double => Tree.Literal(x.toString)
       case x: String =>
-        if (x.exists(c => c == '\n' || c == '\r')) Tree.Literal("\"\"\"" + x + "\"\"\"")
+        if (x.exists(c => c == '\n' || c == '\r' || c == '\\')) Tree.Literal("\"\"\"" + x + "\"\"\"")
         else Tree.Literal(Util.literalize(x, escapeUnicode))
 
       case x: Symbol => Tree.Literal("'" + x.name)

--- a/pprint/test/src-3/test/src/pprint/HorizontalTests.scala
+++ b/pprint/test/src-3/test/src/pprint/HorizontalTests.scala
@@ -46,6 +46,7 @@ object HorizontalTests extends TestSuite{
           val tq = "\"\"\""
           test - Check("i am a cow", """ "i am a cow" """)
           test - Check( """ "hello" """.trim, """ "\"hello\"" """.trim)
+          test - Check( """foo\bar""".trim, " \"\"\"foo\\bar\"\"\" ".trim)
 
           test - Check("\n", s"""
           |$tq


### PR DESCRIPTION
... so that we don't need to escape it and it can be easily copy-pasted.

Old behaviour:
```scala
scala> """foo\bar"""
val res0: String = "foo\\bar"
```

New behaviour:
```scala
scala> """foo\bar"""
val res0: String = """foo\bar"""
```

Special thanks to @maltek for noticing and suggesting.