### PR TITLE
fix rendering of field names with backticks

### DIFF
--- a/pprint/src-2.13/pprint/ProductSupport.scala
+++ b/pprint/src-2.13/pprint/ProductSupport.scala
@@ -2,6 +2,17 @@ package pprint
 
 object ProductSupport {
 
+  private def isIdentifier(name: String) = {
+    def isStart(c: Char) = (c == '_') || (c == '$') || Character.isUnicodeIdentifierStart(c)
+    def isPart(c: Char) = (c == '$') || Character.isUnicodeIdentifierPart(c)
+    name.toList match {
+      case first :: rest if(isStart(first)) =>
+        rest.forall(isPart)
+      case _ =>
+        false
+    }
+  }
+
   def treeifyProductElements(x: Product,
                              walker: Walker,
                              escapeUnicode: Boolean,
@@ -11,8 +22,14 @@ object ProductSupport {
       .zipWithIndex
       .map {
         case (name, i) =>
+          val key = 
+            if(!isIdentifier(name)) {
+              s"`$name`"
+            } else {
+              name
+            }
           val elem = x.productElement(i)
-          Tree.KeyValue(name, walker.treeify(elem, escapeUnicode, showFieldNames))
+          Tree.KeyValue(key, walker.treeify(elem, escapeUnicode, showFieldNames))
       }
   }
 

--- a/pprint/src-3/ProductSupport.scala
+++ b/pprint/src-3/ProductSupport.scala
@@ -2,6 +2,17 @@ package pprint
 
 object ProductSupport {
 
+  private def isIdentifier(name: String) = {
+    def isStart(c: Char) = (c == '_') || (c == '$') || Character.isUnicodeIdentifierStart(c)
+    def isPart(c: Char) = (c == '$') || Character.isUnicodeIdentifierPart(c)
+    name.toList match {
+      case first :: rest if(isStart(first)) =>
+        rest.forall(isPart)
+      case _ =>
+        false
+    }
+  }
+
   def treeifyProductElements(x: Product,
                              walker: Walker,
                              escapeUnicode: Boolean,
@@ -11,8 +22,14 @@ object ProductSupport {
       .zipWithIndex
       .map {
         case (name, i) =>
+          val key = 
+            if(!isIdentifier(name)) {
+              s"`$name`"
+            } else {
+              name
+            }
           val elem = x.productElement(i)
-          Tree.KeyValue(name, walker.treeify(elem, escapeUnicode, showFieldNames))
+          Tree.KeyValue(key, walker.treeify(elem, escapeUnicode, showFieldNames))
       }
   }
 

--- a/pprint/test/src/test/pprint/DerivationTests.scala
+++ b/pprint/test/src/test/pprint/DerivationTests.scala
@@ -168,5 +168,12 @@ object DerivationTests extends TestSuite{
         """C2(List(C1("hello", List("world"))))"""
       )
     }
+    test("field name with backticks"){
+      case class Test(`with backticks`: Boolean, withoutBackticks: Boolean)
+      Check.blackWhiteFields(
+        Test(true, false),
+        """Test(`with backticks` = true, withoutBackticks = false)"""
+      )
+    }
   }
 }


### PR DESCRIPTION
## Problem

I've been using PPrint with case classes that contain text field names using backticks, which are currently rendered incorrectly:

```
case class Test(`with backticks`: Boolean, withoutBackticks: Boolean)
println(pprint(Test(true, false)).plainText)
```

Outputs the field name without backticks:

```
Test(with backticks = true, withoutBackticks = false)
```

It should print:

```
Test(`with backticks` = true, withoutBackticks = false)
```

## Solution

Change `ProductSupport` to add backticks in case the field name isn't a regular identifier. 

## Notes

- The identifier check is based on the [implementation in Scala 3](https://github.com/lampepfl/dotty/blob/a0699ae879836ce0e3aa259e2464fee172704c78/compiler/src/dotty/tools/dotc/util/Chars.scala#L61). I believe it hasn't changed from Scala 2.
- The `ProductSupport` class seems identical in Scala 2 and 3. Should change it to use a single implementation for both?
- I wasn't able to run the build locally. What command should I use? `./mill` and `sbt compile` both fail.